### PR TITLE
Adjust TPA in bios.s to start at 0x2000 and end at 0x14000.  This is …

### DIFF
--- a/bios/bios.s
+++ b/bios/bios.s
@@ -328,8 +328,8 @@ selDrive:           .byte     0xff                                    | drive re
 
                     .even
 memTable:           .word     1                                       | 1 memory region - TPA only
-tpaStart:           .long     0x100000                                | Default: Start of the Transient Program Area
-tpaSize:            .long     0xEB0000                                | Default: Size of the Transient Program Area
+tpaStart:           .long     0x002000                                | Default: Start of the Transient Program Area
+tpaSize:            .long     0x012000                                | Default: Size of the Transient Program Area
 
 *-----------------------------------------------------------------------------------------------------
 * disk parameter headers


### PR DESCRIPTION
…a small TBS sitting below CPM68k.  Later need to reloate cpm up to top of memory to give a much larger TPA.